### PR TITLE
Forward introspected token to upstreams

### DIFF
--- a/apps/boruta_admin/assets/src/components/Forms/FormErrors.vue
+++ b/apps/boruta_admin/assets/src/components/Forms/FormErrors.vue
@@ -24,6 +24,9 @@ const labels = {
   'file': 'File',
   'id_token_signature_alg': 'ID token signature algorithm',
   'forwarded_token_signature_alg': 'Forwarded token signature algorithm',
+  'forwarded_token_signature_secret': 'ID token signature secret',
+  'forwarded_token_signature_public_key': 'ID token signature public key',
+  'forwarded_token_signature_private_key': 'ID token signature private key',
   'resource': 'Resource',
   'is_default': 'Default',
   'password_hashing_opts': 'Password hashing options'

--- a/apps/boruta_admin/assets/src/components/Forms/FormErrors.vue
+++ b/apps/boruta_admin/assets/src/components/Forms/FormErrors.vue
@@ -23,6 +23,7 @@ const labels = {
   'redirect_uris': 'Redirect URIs',
   'file': 'File',
   'id_token_signature_alg': 'ID token signature algorithm',
+  'forwarded_token_signature_alg': 'Forwarded token signature algorithm',
   'resource': 'Resource',
   'is_default': 'Default',
   'password_hashing_opts': 'Password hashing options'

--- a/apps/boruta_admin/assets/src/components/Forms/UpstreamForm.vue
+++ b/apps/boruta_admin/assets/src/components/Forms/UpstreamForm.vue
@@ -85,9 +85,9 @@
             </div>
           </div>
         </div>
-        <div class="field" :class="{ 'error': upstream.errors?.error_content_type }">
-          <label>Error content type</label>
-          <input type="text" v-model="upstream.error_content_type" placeholder="text">
+        <div class="field" :class="{ 'error': upstream.errors?.forwarded_token_secret }">
+          <label>Forwarded token secret <em>(leave blank to autogenerate)</em></label>
+          <input type="text" v-model="upstream.forwarded_token_secret" placeholder="text">
         </div>
         <hr />
         <button class="ui right floated violet button" type="submit">{{ action }}</button>

--- a/apps/boruta_admin/assets/src/components/Forms/UpstreamForm.vue
+++ b/apps/boruta_admin/assets/src/components/Forms/UpstreamForm.vue
@@ -73,6 +73,22 @@
             <textarea v-model="upstream.unauthorized_response" placeholder="You are unauthorized to access this resource."></textarea>
           </div>
         </div>
+        <h3>Forwarded authorization</h3>
+        <div class="ui segment">
+          <div class="inline fields" :class="{ 'error': upstream.errors?.forwarded_token_signature_alg }">
+            <label>Forwarded token signature algorithm</label>
+            <div class="field" v-for="alg in forwardedTokenSignatureAlgorithms" :key="alg">
+              <div class="ui radio checkbox">
+                <label>{{ alg }}</label>
+                <input type="radio" v-model="upstream.forwarded_token_signature_alg" :value="alg" />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="field" :class="{ 'error': upstream.errors?.error_content_type }">
+          <label>Error content type</label>
+          <input type="text" v-model="upstream.error_content_type" placeholder="text">
+        </div>
         <hr />
         <button class="ui right floated violet button" type="submit">{{ action }}</button>
         <a class="ui button" v-on:click="back()">Back</a>
@@ -83,6 +99,7 @@
 
 <script>
 import Scope from '../../models/scope.model'
+import Upstream from '../../models/upstream.model'
 import GatewayScopesField from '../../components/Forms/GatewayScopesField.vue'
 import FormErrors from '../../components/Forms/FormErrors.vue'
 
@@ -92,6 +109,11 @@ export default {
   components: {
     FormErrors,
     GatewayScopesField
+  },
+  data () {
+    return {
+      forwardedTokenSignatureAlgorithms: Upstream.forwardedTokenSignatureAlgorithms
+    }
   },
   methods: {
     back () {

--- a/apps/boruta_admin/assets/src/components/Forms/UpstreamForm.vue
+++ b/apps/boruta_admin/assets/src/components/Forms/UpstreamForm.vue
@@ -85,9 +85,19 @@
             </div>
           </div>
         </div>
-        <div class="field" :class="{ 'error': upstream.errors?.forwarded_token_secret }">
+        <div v-if="isHsAlgorithm" class="field" :class="{ 'error': upstream.errors?.forwarded_token_secret }">
           <label>Forwarded token secret <em>(leave blank to autogenerate)</em></label>
           <input type="text" v-model="upstream.forwarded_token_secret" placeholder="text">
+        </div>
+        <div v-if="isRsAlgorithm">
+          <div class="field" :class="{ 'error': upstream.errors?.forwarded_token_private_key }">
+            <label>Forwarded token private key <em>(leave blank to autogenerate)</em></label>
+            <textarea v-model="upstream.forwarded_token_private_key"></textarea>
+          </div>
+          <div class="field" :class="{ 'error': upstream.errors?.forwarded_token_public_key }">
+            <label>Forwarded token public key</label>
+            <textarea v-model="upstream.forwarded_token_public_key"></textarea>
+          </div>
         </div>
         <hr />
         <button class="ui right floated violet button" type="submit">{{ action }}</button>
@@ -113,6 +123,14 @@ export default {
   data () {
     return {
       forwardedTokenSignatureAlgorithms: Upstream.forwardedTokenSignatureAlgorithms
+    }
+  },
+  computed: {
+    isHsAlgorithm () {
+      return this.upstream.forwarded_token_signature_alg?.match(/HS/)
+    },
+    isRsAlgorithm () {
+      return this.upstream.forwarded_token_signature_alg?.match(/RS/)
     }
   },
   methods: {

--- a/apps/boruta_admin/assets/src/models/upstream.model.js
+++ b/apps/boruta_admin/assets/src/models/upstream.model.js
@@ -22,6 +22,8 @@ const assign = {
   strip_uri: function ({ strip_uri }) { this.strip_uri = strip_uri },
   forwarded_token_signature_alg: function ({ forwarded_token_signature_alg }) { this.forwarded_token_signature_alg = forwarded_token_signature_alg },
   forwarded_token_secret: function ({ forwarded_token_secret }) { this.forwarded_token_secret = forwarded_token_secret },
+  forwarded_token_public_key: function ({ forwarded_token_public_key }) { this.forwarded_token_public_key = forwarded_token_public_key },
+  forwarded_token_private_key: function ({ forwarded_token_private_key }) { this.forwarded_token_private_key = forwarded_token_private_key },
   uris: function ({ uris }) {
     this.uris = uris.map((uri) => ({ uri }))
   },
@@ -106,7 +108,9 @@ class Upstream {
       forbidden_response,
       unauthorized_response,
       forwarded_token_signature_alg,
-      forwarded_token_secret
+      forwarded_token_secret,
+      forwarded_token_private_key,
+      forwarded_token_public_key
     } = this
 
     return {
@@ -129,7 +133,9 @@ class Upstream {
       forbidden_response,
       unauthorized_response,
       forwarded_token_signature_alg,
-      forwarded_token_secret
+      forwarded_token_secret,
+      forwarded_token_private_key,
+      forwarded_token_public_key
     }
   }
 }

--- a/apps/boruta_admin/assets/src/models/upstream.model.js
+++ b/apps/boruta_admin/assets/src/models/upstream.model.js
@@ -20,6 +20,7 @@ const assign = {
   pool_count: function ({ pool_count }) { this.pool_count = pool_count },
   max_idle_time: function ({ max_idle_time }) { this.max_idle_time = max_idle_time },
   strip_uri: function ({ strip_uri }) { this.strip_uri = strip_uri },
+  forwarded_token_signature_alg: function ({ forwarded_token_signature_alg }) { this.forwarded_token_signature_alg = forwarded_token_signature_alg },
   uris: function ({ uris }) {
     this.uris = uris.map((uri) => ({ uri }))
   },
@@ -102,7 +103,8 @@ class Upstream {
       required_scopes,
       error_content_type,
       forbidden_response,
-      unauthorized_response
+      unauthorized_response,
+      forwarded_token_signature_alg
     } = this
 
     return {
@@ -123,7 +125,8 @@ class Upstream {
       authorize,
       error_content_type,
       forbidden_response,
-      unauthorized_response
+      unauthorized_response,
+      forwarded_token_signature_alg
     }
   }
 }
@@ -150,5 +153,14 @@ Upstream.get = function (id) {
     return new Upstream(data.data)
   })
 }
+
+Upstream.forwardedTokenSignatureAlgorithms = [
+  "HS256",
+  "HS384",
+  "HS512",
+  "RS256",
+  "RS384",
+  "RS512"
+]
 
 export default Upstream

--- a/apps/boruta_admin/assets/src/models/upstream.model.js
+++ b/apps/boruta_admin/assets/src/models/upstream.model.js
@@ -21,6 +21,7 @@ const assign = {
   max_idle_time: function ({ max_idle_time }) { this.max_idle_time = max_idle_time },
   strip_uri: function ({ strip_uri }) { this.strip_uri = strip_uri },
   forwarded_token_signature_alg: function ({ forwarded_token_signature_alg }) { this.forwarded_token_signature_alg = forwarded_token_signature_alg },
+  forwarded_token_secret: function ({ forwarded_token_secret }) { this.forwarded_token_secret = forwarded_token_secret },
   uris: function ({ uris }) {
     this.uris = uris.map((uri) => ({ uri }))
   },
@@ -104,7 +105,8 @@ class Upstream {
       error_content_type,
       forbidden_response,
       unauthorized_response,
-      forwarded_token_signature_alg
+      forwarded_token_signature_alg,
+      forwarded_token_secret
     } = this
 
     return {
@@ -126,7 +128,8 @@ class Upstream {
       error_content_type,
       forbidden_response,
       unauthorized_response,
-      forwarded_token_signature_alg
+      forwarded_token_signature_alg,
+      forwarded_token_secret
     }
   }
 }

--- a/apps/boruta_admin/lib/boruta_admin_web/views/upstream_view.ex
+++ b/apps/boruta_admin/lib/boruta_admin_web/views/upstream_view.ex
@@ -26,7 +26,8 @@ defmodule BorutaAdminWeb.UpstreamView do
       error_content_type: upstream.error_content_type,
       forbidden_response: upstream.forbidden_response,
       unauthorized_response: upstream.unauthorized_response,
-      forwarded_token_signature_alg: upstream.forwarded_token_signature_alg
+      forwarded_token_signature_alg: upstream.forwarded_token_signature_alg,
+      forwarded_token_secret: upstream.forwarded_token_secret
     }
   end
 end

--- a/apps/boruta_admin/lib/boruta_admin_web/views/upstream_view.ex
+++ b/apps/boruta_admin/lib/boruta_admin_web/views/upstream_view.ex
@@ -25,7 +25,8 @@ defmodule BorutaAdminWeb.UpstreamView do
       max_idle_time: upstream.max_idle_time,
       error_content_type: upstream.error_content_type,
       forbidden_response: upstream.forbidden_response,
-      unauthorized_response: upstream.unauthorized_response
+      unauthorized_response: upstream.unauthorized_response,
+      forwarded_token_signature_alg: upstream.forwarded_token_signature_alg
     }
   end
 end

--- a/apps/boruta_admin/lib/boruta_admin_web/views/upstream_view.ex
+++ b/apps/boruta_admin/lib/boruta_admin_web/views/upstream_view.ex
@@ -27,7 +27,9 @@ defmodule BorutaAdminWeb.UpstreamView do
       forbidden_response: upstream.forbidden_response,
       unauthorized_response: upstream.unauthorized_response,
       forwarded_token_signature_alg: upstream.forwarded_token_signature_alg,
-      forwarded_token_secret: upstream.forwarded_token_secret
+      forwarded_token_secret: upstream.forwarded_token_secret,
+      forwarded_token_private_key: upstream.forwarded_token_private_key,
+      forwarded_token_public_key: upstream.forwarded_token_public_key
     }
   end
 end

--- a/apps/boruta_gateway/lib/boruta_gateway/upstreams/upstream.ex
+++ b/apps/boruta_gateway/lib/boruta_gateway/upstreams/upstream.ex
@@ -52,6 +52,7 @@ defmodule BorutaGateway.Upstreams.Upstream do
     field(:error_content_type, :string)
     field(:forbidden_response, :string)
     field(:unauthorized_response, :string)
+    field(:forwarded_token_signature_alg, :string)
 
     field(:http_client, :any, virtual: true)
 
@@ -101,7 +102,8 @@ defmodule BorutaGateway.Upstreams.Upstream do
       :max_idle_time,
       :error_content_type,
       :forbidden_response,
-      :unauthorized_response
+      :unauthorized_response,
+      :forwarded_token_signature_alg
     ])
     |> validate_required([:scheme, :host, :port])
     |> validate_inclusion(:scheme, ["http", "https"])

--- a/apps/boruta_gateway/priv/repo/migrations/20221024100810_add_forwarded_token_signature_algorithm_to_upstreams.exs
+++ b/apps/boruta_gateway/priv/repo/migrations/20221024100810_add_forwarded_token_signature_algorithm_to_upstreams.exs
@@ -1,0 +1,9 @@
+defmodule BorutaGateway.Repo.Migrations.AddForwardedTokenSignatureAlgorithmToUpstreams do
+  use Ecto.Migration
+
+  def change do
+    alter table(:upstreams) do
+      add :forwarded_token_signature_alg, :string
+    end
+  end
+end

--- a/apps/boruta_gateway/priv/repo/migrations/20221024122642_add_forwarded_token_secret_to_upstreams.exs
+++ b/apps/boruta_gateway/priv/repo/migrations/20221024122642_add_forwarded_token_secret_to_upstreams.exs
@@ -1,0 +1,9 @@
+defmodule BorutaGateway.Repo.Migrations.AddForwardedTokenSecretToUpstreams do
+  use Ecto.Migration
+
+  def change do
+    alter table(:upstreams) do
+      add :forwarded_token_secret, :string
+    end
+  end
+end

--- a/apps/boruta_gateway/priv/repo/migrations/20221024132312_add_forwarded_token_key_pair_to_upstreams.exs
+++ b/apps/boruta_gateway/priv/repo/migrations/20221024132312_add_forwarded_token_key_pair_to_upstreams.exs
@@ -1,0 +1,10 @@
+defmodule BorutaGateway.Repo.Migrations.AddForwardedTokenKeyPairToUpstreams do
+  use Ecto.Migration
+
+  def change do
+    alter table(:upstreams) do
+      add :forwarded_token_public_key, :text
+      add :forwarded_token_private_key, :text
+    end
+  end
+end

--- a/apps/boruta_gateway/test/boruta_gateway/upstreams/client_test.exs
+++ b/apps/boruta_gateway/test/boruta_gateway/upstreams/client_test.exs
@@ -84,7 +84,7 @@ defmodule BorutaGateway.Upstreams.ClientTest do
           req_headers = Jason.decode!(body)["headers"]
 
           assert Enum.any?(req_headers, fn
-                   {"Authorization", "Bearer test"} -> true
+                   {"X-Forwarded-Authorization", "Bearer test"} -> true
                    _ -> false
                  end)
 

--- a/apps/boruta_gateway/test/boruta_gateway/upstreams_test.exs
+++ b/apps/boruta_gateway/test/boruta_gateway/upstreams_test.exs
@@ -54,6 +54,19 @@ defmodule BorutaGateway.UpstreamsTest do
       assert {:ok, %Upstream{}} = Upstreams.create_upstream(@valid_attrs)
     end
 
+    test "create_upstream/1 generates a secret with HS* algorithms" do
+      assert {:ok, %Upstream{forwarded_token_secret: forwarded_token_secret}} =
+               Upstreams.create_upstream(
+                 Map.put(
+                   @valid_attrs,
+                   :forwarded_token_signature_alg,
+                   "HS256"
+                 )
+               )
+
+      assert forwarded_token_secret
+    end
+
     test "create_upstream/1 with invalid data returns error changeset" do
       assert {:error,
               %Ecto.Changeset{

--- a/apps/boruta_gateway/test/boruta_gateway/upstreams_test.exs
+++ b/apps/boruta_gateway/test/boruta_gateway/upstreams_test.exs
@@ -67,6 +67,23 @@ defmodule BorutaGateway.UpstreamsTest do
       assert forwarded_token_secret
     end
 
+    test "create_upstream/1 generates a secret with RS* algorithms" do
+      assert {:ok, %Upstream{
+        forwarded_token_private_key: forwarded_token_private_key,
+        forwarded_token_public_key: forwarded_token_public_key
+      }} =
+               Upstreams.create_upstream(
+                 Map.put(
+                   @valid_attrs,
+                   :forwarded_token_signature_alg,
+                   "RS256"
+                 )
+               )
+
+      assert forwarded_token_private_key
+      assert forwarded_token_public_key
+    end
+
     test "create_upstream/1 with invalid data returns error changeset" do
       assert {:error,
               %Ecto.Changeset{


### PR DESCRIPTION
This PR enables upstreams to receive an "Authorization" header containing information from an introspected token. The former header is set as "X-Forwarded-Authorization".