### PR TITLE
Split boruta releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,6 +92,84 @@ jobs:
             ${{ env.REGISTRY }}/malach-it/boruta-gateway:${{ github.head_ref || github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}
 
+  build-and-push-auth-image:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - uses: benjlevesque/short-sha@v1.2
+        id: short-sha
+        with:
+          length: 8
+
+      - name: Build and push auth Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          file: Dockerfile.auth
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/malach-it/boruta-auth:${{ steps.short-sha.outputs.sha }},
+            ${{ env.REGISTRY }}/malach-it/boruta-auth:${{ github.head_ref || github.ref_name }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-and-push-admin-image:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - uses: benjlevesque/short-sha@v1.2
+        id: short-sha
+        with:
+          length: 8
+
+      - name: Build and push admin Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          file: Dockerfile.admin
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/malach-it/boruta-admin:${{ steps.short-sha.outputs.sha }},
+            ${{ env.REGISTRY }}/malach-it/boruta-admin:${{ github.head_ref || github.ref_name }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   deploy:
     runs-on: ubuntu-20.04
     needs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push-image:
+  build-and-push-server-image:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -42,17 +42,61 @@ jobs:
         with:
           length: 8
 
-      - name: Build and push Docker image
+      - name: Build and push server Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
+          file: Dockerfile.full
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.short-sha.outputs.sha }}, ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ env.REGISTRY }}/malach-it/boruta-server:${{ steps.short-sha.outputs.sha }},
+            ${{ env.REGISTRY }}/malach-it/boruta-gateway:${{ github.head_ref || github.ref_name }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build-and-push-gateway-image:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - uses: benjlevesque/short-sha@v1.2
+        id: short-sha
+        with:
+          length: 8
+
+      - name: Build and push gateway Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          file: Dockerfile.gateway
+          context: .
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/malach-it/boruta-gateway:${{ steps.short-sha.outputs.sha }},
+            ${{ env.REGISTRY }}/malach-it/boruta-gateway:${{ github.head_ref || github.ref_name }}
           labels: ${{ steps.meta.outputs.labels }}
 
   deploy:
     runs-on: ubuntu-20.04
-    needs: build-and-push-image
+    needs:
+      - build-and-push-server-image
+      - build-and-push-gateway-image
 
     steps:
       - name: Checkout repository

--- a/Dockerfile.admin
+++ b/Dockerfile.admin
@@ -1,0 +1,42 @@
+FROM node:17.4.0 AS assets
+
+# For packages not compatible with OpenSSL 3.0 https://nodejs.org/en/blog/release/v17.0.0/
+ENV NODE_OPTIONS=--openssl-legacy-provider
+
+WORKDIR /app
+
+COPY ./apps/boruta_admin/assets /app
+
+RUN npm ci
+RUN npm run build
+
+FROM elixir:1.14-otp-25-slim AS builder
+
+RUN apt-get update
+RUN apt-get install -y git build-essential
+
+ENV MIX_ENV=prod
+
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+WORKDIR /app
+COPY . .
+COPY --from=assets /priv ./apps/boruta_admin/priv/
+RUN rm -rf deps
+RUN mix do clean, deps.get
+RUN mix compile
+
+WORKDIR /app/apps/boruta_admin
+RUN mix phx.digest
+
+WORKDIR /app
+RUN mix release boruta_admin --force --overwrite
+
+FROM elixir:1.14-otp-25-slim
+
+WORKDIR /app
+
+COPY --from=builder /app/_build/prod/rel/boruta_admin ./
+
+CMD ["/bin/sh", "-c", "/app/bin/boruta_admin start"]

--- a/Dockerfile.auth
+++ b/Dockerfile.auth
@@ -1,0 +1,31 @@
+FROM elixir:1.14-otp-25-slim AS builder
+
+RUN apt-get update
+RUN apt-get install -y git build-essential
+
+ENV MIX_ENV=prod
+
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+WORKDIR /app
+COPY . .
+RUN rm -rf deps
+RUN mix do clean, deps.get
+RUN mix compile
+
+WORKDIR /app/apps/boruta_identity
+RUN mix phx.digest
+WORKDIR /app/apps/boruta_web
+RUN mix phx.digest
+
+WORKDIR /app
+RUN mix release boruta_auth --force --overwrite
+
+FROM elixir:1.14-otp-25-slim
+
+WORKDIR /app
+
+COPY --from=builder /app/_build/prod/rel/boruta_auth ./
+
+CMD ["/bin/sh", "-c", "/app/bin/boruta_auth start"]

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -35,13 +35,13 @@ WORKDIR /app/apps/boruta_web
 RUN mix phx.digest
 
 WORKDIR /app
-RUN mix release boruta_full --force --overwrite
+RUN mix release boruta --force --overwrite
 
 FROM elixir:1.14-otp-25-slim
 
 WORKDIR /app
 
-COPY --from=builder /app/_build/prod/rel/boruta_full ./
+COPY --from=builder /app/_build/prod/rel/boruta ./
 
 # File used for gateway static configuration, used in combination with `BORUTA_GATEWAY_CONFIGURATION_PATH` environment variable
 COPY /static_config/example-gateway-configuration.yml config/example-gateway-configuration.yml
@@ -49,4 +49,4 @@ COPY /static_config/example-gateway-configuration.yml config/example-gateway-con
 COPY /static_config/example-httpbin-configuration.yml config/example-httpbin-configuration.yml
 COPY /static_config/example-protected-httpbin-configuration.yml config/example-protected-httpbin-configuration.yml
 
-CMD ["/bin/sh", "-c", "/app/bin/boruta_full start"]
+CMD ["/bin/sh", "-c", "/app/bin/boruta start"]

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,0 +1,52 @@
+FROM node:17.4.0 AS assets
+
+# For packages not compatible with OpenSSL 3.0 https://nodejs.org/en/blog/release/v17.0.0/
+ENV NODE_OPTIONS=--openssl-legacy-provider
+
+WORKDIR /app
+
+COPY ./apps/boruta_admin/assets /app
+
+RUN npm ci
+RUN npm run build
+
+FROM elixir:1.14-otp-25-slim AS builder
+
+RUN apt-get update
+RUN apt-get install -y git build-essential
+
+ENV MIX_ENV=prod
+
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+WORKDIR /app
+COPY . .
+COPY --from=assets /priv ./apps/boruta_admin/priv/
+RUN rm -rf deps
+RUN mix do clean, deps.get
+RUN mix compile
+
+WORKDIR /app/apps/boruta_admin
+RUN mix phx.digest
+WORKDIR /app/apps/boruta_identity
+RUN mix phx.digest
+WORKDIR /app/apps/boruta_web
+RUN mix phx.digest
+
+WORKDIR /app
+RUN mix release boruta_full --force --overwrite
+
+FROM elixir:1.14-otp-25-slim
+
+WORKDIR /app
+
+COPY --from=builder /app/_build/prod/rel/boruta_full ./
+
+# File used for gateway static configuration, used in combination with `BORUTA_GATEWAY_CONFIGURATION_PATH` environment variable
+COPY /static_config/example-gateway-configuration.yml config/example-gateway-configuration.yml
+
+COPY /static_config/example-httpbin-configuration.yml config/example-httpbin-configuration.yml
+COPY /static_config/example-protected-httpbin-configuration.yml config/example-protected-httpbin-configuration.yml
+
+CMD ["/bin/sh", "-c", "/app/bin/boruta_full start"]

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -1,15 +1,3 @@
-FROM node:17.4.0 AS assets
-
-# For packages not compatible with OpenSSL 3.0 https://nodejs.org/en/blog/release/v17.0.0/
-ENV NODE_OPTIONS=--openssl-legacy-provider
-
-WORKDIR /app
-
-COPY ./apps/boruta_admin/assets /app
-
-RUN npm ci
-RUN npm run build
-
 FROM elixir:1.14-otp-25-slim AS builder
 
 RUN apt-get update
@@ -22,26 +10,18 @@ RUN mix local.rebar --force
 
 WORKDIR /app
 COPY . .
-COPY --from=assets /priv ./apps/boruta_admin/priv/
 RUN rm -rf deps
 RUN mix do clean, deps.get
 RUN mix compile
 
-WORKDIR /app/apps/boruta_admin
-RUN mix phx.digest
-WORKDIR /app/apps/boruta_identity
-RUN mix phx.digest
-WORKDIR /app/apps/boruta_web
-RUN mix phx.digest
-
 WORKDIR /app
-RUN mix release --force --overwrite
+RUN mix release boruta_gateway --force --overwrite
 
 FROM elixir:1.14-otp-25-slim
 
 WORKDIR /app
 
-COPY --from=builder /app/_build/prod/rel/boruta ./
+COPY --from=builder /app/_build/prod/rel/boruta_gateway ./
 
 # File used for gateway static configuration, used in combination with `BORUTA_GATEWAY_CONFIGURATION_PATH` environment variable
 COPY /static_config/example-gateway-configuration.yml config/example-gateway-configuration.yml
@@ -49,4 +29,4 @@ COPY /static_config/example-gateway-configuration.yml config/example-gateway-con
 COPY /static_config/example-httpbin-configuration.yml config/example-httpbin-configuration.yml
 COPY /static_config/example-protected-httpbin-configuration.yml config/example-protected-httpbin-configuration.yml
 
-CMD ["/bin/sh", "-c", "/app/bin/boruta start"]
+CMD ["/bin/sh", "-c", "/app/bin/boruta_gateway start"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ docker-compose build
 2. run database migrations
 
 ```bash
-docker-compose run boruta ./bin/boruta eval "Boruta.Release.setup()"
+docker-compose run boruta ./bin/boruta eval "BorutaWeb.Release.setup()"
+docker-compose run boruta ./bin/boruta eval "BorutaGateway.Release.setup()"
 ```
 
 Once done, you can run the docker images as follow:
@@ -86,7 +87,8 @@ MIX_ENV=prod mix release
 4. finally setup database
 
 ```bash
-env $(cat .env.example | xargs) _build/prod/rel/boruta/bin/boruta eval "Boruta.Release.setup()"
+env $(cat .env.example | xargs) _build/prod/rel/boruta/bin/boruta eval "BorutaWeb.Release.setup()"
+env $(cat .env.example | xargs) _build/prod/rel/boruta/bin/boruta eval "BorutaGateway.Release.setup()"
 ```
 
 Once done, you can run the release as follow:

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -218,7 +218,7 @@
               spec:
                 containers:
                   - image: "ghcr.io/malach-it/boruta-server:master"
-                    command: ["/app/bin/boruta_full"]
+                    command: ["/app/bin/boruta"]
                     args: ["eval", "BorutaWeb.Release.setup"]
                     envFrom:
                     - configMapRef:
@@ -481,7 +481,7 @@
               spec:
                 containers:
                   - image: "ghcr.io/malach-it/boruta-server:{{ release_tag }}"
-                    command: ["/app/bin/boruta_full"]
+                    command: ["/app/bin/boruta"]
                     args: ["eval", "BorutaWeb.Release.migrate"]
                     envFrom:
                     - configMapRef:
@@ -508,7 +508,7 @@
               spec:
                 containers:
                   - image: "ghcr.io/malach-it/boruta-server:{{ release_tag }}"
-                    command: ["/app/bin/boruta_full"]
+                    command: ["/app/bin/boruta"]
                     args: ["eval", "BorutaGateway.Release.load_configuration"]
                     env:
                       - name: BORUTA_GATEWAY_CONFIGURATION_PATH

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -200,9 +200,9 @@
             BORUTA_OAUTH_BASE_URL: "{{ oauth_base_url }}"
             BORUTA_GATEWAY_PORT: "5000"
             BORUTA_GATEWAY_SIDECAR_PORT: "5001"
-            POOL_SIZE: "20"
+            POOL_SIZE: "5"
 
-    - name: Setup boruta database
+    - name: Setup boruta auth database
       register: database_setup
       kubernetes.core.k8s:
         state: present
@@ -210,16 +210,43 @@
           apiVersion: batch/v1
           kind: Job
           metadata:
-            name: boruta-setup
+            name: boruta-auth-setup
             namespace: boruta-staging
           backoffLimit: 3
           spec:
             template:
               spec:
                 containers:
-                  - image: ghcr.io/malach-it/boruta-server:master
-                    command: ["/app/bin/boruta"]
-                    args: ["eval", "Boruta.Release.setup"]
+                  - image: "ghcr.io/malach-it/boruta-server:master"
+                    command: ["/app/bin/boruta_full"]
+                    args: ["eval", "BorutaWeb.Release.setup"]
+                    envFrom:
+                    - configMapRef:
+                        name: boruta-env
+                    imagePullPolicy: Always
+                    name: boruta
+                restartPolicy: OnFailure
+                imagePullSecrets:
+                  - name: dockerconfigjson-github-com
+
+    - name: Setup boruta gateway database
+      register: database_setup
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: boruta-gateway-setup
+            namespace: boruta-staging
+          backoffLimit: 3
+          spec:
+            template:
+              spec:
+                containers:
+                  - image: "ghcr.io/malach-it/boruta-gateway:master"
+                    command: ["/app/bin/boruta_gateway"]
+                    args: ["eval", "BorutaGateway.Release.setup"]
                     envFrom:
                     - configMapRef:
                         name: boruta-env
@@ -342,11 +369,11 @@
                     persistentVolumeClaim:
                       claimName: boruta-logs-pvc
                 containers:
-                  - image: "ghcr.io/malach-it/boruta-server:{{ release_tag }}"
+                  - image: "ghcr.io/malach-it/boruta-gateway:{{ release_tag }}"
                     readinessProbe:
                       httpGet:
-                        path: /healthcheck
-                        port: 4001
+                        path: /
+                        port: 5001
                     env:
                       - name: BORUTA_GATEWAY_CONFIGURATION_PATH
                         value: "./config/example-httpbin-configuration.yml"
@@ -390,11 +417,11 @@
                     persistentVolumeClaim:
                       claimName: boruta-logs-pvc
                 containers:
-                  - image: "ghcr.io/malach-it/boruta-server:{{ release_tag }}"
+                  - image: "ghcr.io/malach-it/boruta-gateway:{{ release_tag }}"
                     readinessProbe:
                       httpGet:
-                        path: /healthcheck
-                        port: 4001
+                        path: /
+                        port: 5001
                     env:
                       - name: BORUTA_GATEWAY_CONFIGURATION_PATH
                         value: "./config/example-protected-httpbin-configuration.yml"
@@ -409,7 +436,7 @@
                 imagePullSecrets:
                 - name: dockerconfigjson-github-com
 
-    - name: Migrate boruta database
+    - name: Migrate boruta gateway database
       when: not database_setup.changed
       kubernetes.core.k8s:
         state: present
@@ -417,7 +444,7 @@
           apiVersion: batch/v1
           kind: Job
           metadata:
-            name: "boruta-migration-{{ release_tag }}"
+            name: "boruta-gateway-migration-{{ release_tag }}"
             namespace: boruta-staging
           backoffLimit: 3
           spec:
@@ -426,8 +453,36 @@
               spec:
                 containers:
                   - image: "ghcr.io/malach-it/boruta-server:{{ release_tag }}"
-                    command: ["/app/bin/boruta"]
-                    args: ["eval", "Boruta.Release.migrate"]
+                    command: ["/app/bin/boruta_gateway"]
+                    args: ["eval", "BorutaGateway.Release.migrate"]
+                    envFrom:
+                    - configMapRef:
+                        name: boruta-env
+                    imagePullPolicy: Always
+                    name: boruta
+                restartPolicy: OnFailure
+                imagePullSecrets:
+                  - name: dockerconfigjson-github-com
+
+    - name: Migrate boruta web database
+      when: not database_setup.changed
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: "boruta-auth-migration-{{ release_tag }}"
+            namespace: boruta-staging
+          backoffLimit: 3
+          spec:
+            ttlSecondsAfterFinished: 864000
+            template:
+              spec:
+                containers:
+                  - image: "ghcr.io/malach-it/boruta-server:{{ release_tag }}"
+                    command: ["/app/bin/boruta_full"]
+                    args: ["eval", "BorutaWeb.Release.migrate"]
                     envFrom:
                     - configMapRef:
                         name: boruta-env
@@ -453,8 +508,8 @@
               spec:
                 containers:
                   - image: "ghcr.io/malach-it/boruta-server:{{ release_tag }}"
-                    command: ["/app/bin/boruta"]
-                    args: ["eval", "Boruta.Release.load_configuration"]
+                    command: ["/app/bin/boruta_full"]
+                    args: ["eval", "BorutaGateway.Release.load_configuration"]
                     env:
                       - name: BORUTA_GATEWAY_CONFIGURATION_PATH
                         value: "./config/example-gateway-configuration.yml"
@@ -482,9 +537,9 @@
             template:
               spec:
                 containers:
-                  - image: "ghcr.io/malach-it/boruta-server:{{ release_tag }}"
-                    command: ["/app/bin/boruta"]
-                    args: ["eval", "Boruta.Release.load_configuration"]
+                  - image: "ghcr.io/malach-it/boruta-gateway:{{ release_tag }}"
+                    command: ["/app/bin/boruta_gateway"]
+                    args: ["eval", "BorutaGateway.Release.load_configuration"]
                     env:
                       - name: BORUTA_GATEWAY_CONFIGURATION_PATH
                         value: "./config/example-httpbin-configuration.yml"
@@ -512,9 +567,9 @@
             template:
               spec:
                 containers:
-                  - image: "ghcr.io/malach-it/boruta-server:{{ release_tag }}"
-                    command: ["/app/bin/boruta"]
-                    args: ["eval", "Boruta.Release.load_configuration"]
+                  - image: "ghcr.io/malach-it/boruta-gateway:{{ release_tag }}"
+                    command: ["/app/bin/boruta_gateway"]
+                    args: ["eval", "BorutaGateway.Release.load_configuration"]
                     env:
                       - name: BORUTA_GATEWAY_CONFIGURATION_PATH
                         value: "./config/example-protected-httpbin-configuration.yml"

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -370,10 +370,6 @@
                       claimName: boruta-logs-pvc
                 containers:
                   - image: "ghcr.io/malach-it/boruta-gateway:{{ release_tag }}"
-                    readinessProbe:
-                      httpGet:
-                        path: /
-                        port: 5001
                     env:
                       - name: BORUTA_GATEWAY_CONFIGURATION_PATH
                         value: "./config/example-httpbin-configuration.yml"
@@ -418,10 +414,6 @@
                       claimName: boruta-logs-pvc
                 containers:
                   - image: "ghcr.io/malach-it/boruta-gateway:{{ release_tag }}"
-                    readinessProbe:
-                      httpGet:
-                        path: /
-                        port: 5001
                     env:
                       - name: BORUTA_GATEWAY_CONFIGURATION_PATH
                         value: "./config/example-protected-httpbin-configuration.yml"

--- a/apps/boruta_gateway/lib/boruta_gateway/release.ex
+++ b/apps/boruta_gateway/lib/boruta_gateway/release.ex
@@ -1,6 +1,6 @@
 defmodule BorutaGateway.Release do
   @moduledoc false
-  @apps [:boruta_gateway]
+  @apps [:boruta_auth, :boruta_gateway]
 
   def migrate do
     for repo <- repos() do

--- a/apps/boruta_gateway/lib/boruta_gateway/release.ex
+++ b/apps/boruta_gateway/lib/boruta_gateway/release.ex
@@ -1,0 +1,38 @@
+defmodule BorutaGateway.Release do
+  @moduledoc false
+  @apps [:boruta_gateway]
+
+  def migrate do
+    for repo <- repos() do
+      repo.__adapter__.storage_up(repo.config)
+
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+    end
+  end
+
+  def load_configuration do
+    Application.ensure_all_started(:boruta_gateway)
+
+    configuration_path = Application.get_env(:boruta_gateway, :configuration_path)
+
+    BorutaGateway.ConfigurationLoader.from_file!(configuration_path)
+  end
+
+  def rollback(repo, version) do
+    repo.__adapter__.storage_up(repo.config)
+
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+  end
+
+  def setup do
+    migrate()
+  end
+
+  defp repos do
+    Enum.flat_map(@apps, fn app ->
+      Application.load(app)
+      Application.fetch_env!(app, :ecto_repos)
+    end)
+    |> Enum.uniq()
+  end
+end

--- a/apps/boruta_web/lib/boruta_web/release.ex
+++ b/apps/boruta_web/lib/boruta_web/release.ex
@@ -1,6 +1,6 @@
-defmodule Boruta.Release do
+defmodule BorutaWeb.Release do
   @moduledoc false
-  @apps [:boruta_auth, :boruta_identity, :boruta_gateway, :boruta_web]
+  @apps [:boruta_auth, :boruta_identity, :boruta_web]
 
   def migrate do
     for repo <- repos() do
@@ -8,14 +8,6 @@ defmodule Boruta.Release do
 
       {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
     end
-  end
-
-  def load_configuration do
-    Application.ensure_all_started(:boruta_gateway)
-
-    configuration_path = Application.get_env(:boruta_gateway, :configuration_path)
-
-    BorutaGateway.ConfigurationLoader.from_file!(configuration_path)
   end
 
   def rollback(repo, version) do

--- a/apps/boruta_web/log/2023-06-15_boruta_admin_request.log
+++ b/apps/boruta_web/log/2023-06-15_boruta_admin_request.log
@@ -1,0 +1,1 @@
+2023-06-15T09:05:53.825Z request_id=F2jJz4J4QSW1nxkAAAKl [info] boruta_admin GET /api/backends/ - sent 200 in 291ms

--- a/apps/boruta_web/mix.exs
+++ b/apps/boruta_web/mix.exs
@@ -38,7 +38,6 @@ defmodule BorutaWeb.MixProject do
     [
       {:boruta_auth, in_umbrella: true},
       {:boruta_identity, in_umbrella: true},
-      {:boruta_gateway, in_umbrella: true},
       {:bypass, "~> 2.1.0", only: :test},
       {:cors_plug, "~> 3.0"},
       {:ex_machina, "~> 2.4", only: :test},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,37 +17,21 @@ services:
       retries: 5
 
   boruta:
-    build: .
+    image: ghcr.io/malach-it/boruta-server:master
     ports:
       - "8080:8080"
       - "8081:8081"
       - "8082:8082"
+      - "8083:8083"
     volumes:
       - "boruta-logs:/app/log"
+    env_file: "../.env.example"
     environment:
       MIX_ENV: "prod"
-      SECRET_KEY_BASE: "5j5St23466R8mTvdfp67vROMqUlNfMxSGzFILSupM1ZcM+0mdql58+R+bhby9Aou"
       POSTGRES_USER: "postgres"
       POSTGRES_PASSWORD: "postgres"
       POSTGRES_DATABASE: "boruta_release"
       POSTGRES_HOST: "postgres"
-      POOL_SIZE: "5"
-      BORUTA_ADMIN_OAUTH_CLIENT_ID: "5905075e-8c62-4b53-9f19-154b0ef2b0e0"
-      BORUTA_ADMIN_OAUTH_CLIENT_SECRET: "mxvJyO5PHMMpodZVJXoZpRFmEqAqqGjMpyNq8uXpBLe6V4ScBH5POHYqUQit66AbWLfAuBlZUS9pQnSGZUG4t"
-      BORUTA_ADMIN_OAUTH_BASE_URL: "http://localhost:8080"
-      BORUTA_ADMIN_EMAIL: "admin@test.test"
-      BORUTA_ADMIN_PASSWORD: "imaynotknowthat"
-      BORUTA_ADMIN_HOST: "localhost"
-      BORUTA_ADMIN_PORT: "8081"
-      BORUTA_ADMIN_BASE_URL: "http://localhost:8081"
-      BORUTA_ADMIN_BASE_SOCKET_URL: "ws://localhost:8081"
-      BORUTA_OAUTH_HOST: "localhost"
-      BORUTA_OAUTH_PORT: "8080"
-      BORUTA_OAUTH_BASE_URL: "http://localhost:8080"
-      BORUTA_GATEWAY_PORT: "8082"
-      BORUTA_GATEWAY_SIDECAR_PORT: "8083"
-      MAILJET_API_KEY: "MAILJET_API_KEY"
-      MAILJET_SECRET: "MAILJET_SECRET"
     depends_on:
       postgres:
         condition: service_healthy

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,36 @@
+# example configurations
+
+## Sidecar authorization gateways
+
+located at `examples/sidecar-authorization-gateways`
+
+
+1. run database migrations
+
+```bash
+docker-compose run boruta-server ./bin/boruta eval "BorutaWeb.Release.setup()"
+docker-compose run boruta-server ./bin/boruta eval "BorutaGateway.Release.setup()"
+```
+
+2. load (micro)gateways configuration
+
+```
+docker-compose run boruta-server ./bin/boruta eval "BorutaGateway.Release.load_configuration()"
+docker-compose run httpbin-sidecar ./bin/boruta_gateway eval "BorutaGateway.Release.load_configuration()"
+docker-compose run protected-httpbin-sidecar ./bin/boruta_gateway eval "BorutaGateway.Release.load_configuration()"
+```
+
+Once done, you can run the docker images as follow:
+
+```bash
+docker-compose up
+```
+
+The applications will be available on different ports (depending on the docker compose environment configuration):
+- http://localhost:8080 for the authorization server
+- http://localhost:8081 for the admin interface
+- http://localhost:8082 for the gateway
+
+The gateway will have two endpoints:
+- `http://localhost:8082/httpbin` which expose the httpbin service publicly
+- `http://localhost:8082/protected-httpbin` which expose the httpbin and restrict traffic to test scope granted users

--- a/examples/sidecar-authorization-gateways/config/example-gateway-configuration.yml
+++ b/examples/sidecar-authorization-gateways/config/example-gateway-configuration.yml
@@ -10,9 +10,9 @@ configuration:
       pool_count: 1
       pool_size: 10
       max_idle_time: 10
-      scheme: "https"
-      host: "httpbin.boruta.patatoid.fr"
-      port: 443
+      scheme: "http"
+      host: "httpbin-sidecar"
+      port: 8083
       uris: ["/httpbin"]
       strip_uri: true
     - authorize: false
@@ -24,8 +24,8 @@ configuration:
       pool_count: 1
       pool_size: 10
       max_idle_time: 10
-      scheme: "https"
-      host: "protected-httpbin.boruta.patatoid.fr"
-      port: 443
+      scheme: "http"
+      host: "protected-httpbin-sidecar"
+      port: 8083
       uris: ["/protected-httpbin"]
       strip_uri: true

--- a/examples/sidecar-authorization-gateways/config/example-httpbin-configuration.yml
+++ b/examples/sidecar-authorization-gateways/config/example-httpbin-configuration.yml
@@ -3,7 +3,7 @@ configuration:
   node_name: "httpbin"
   microgateway:
     - authorize: false
-      error_content_type: "text/plain"
+      error_content_type: "text"
       forbidden_response: "forbidden"
       unauthorized_response: "unauthorized"
       forwarded_token_secret: "this is a secret"
@@ -12,7 +12,7 @@ configuration:
       pool_size: 10
       max_idle_time: 10
       scheme: "http"
-      host: "httpbin.patatoid.fr"
+      host: "httpbin"
       port: 80
       uris: ["/"]
       strip_uri: false

--- a/examples/sidecar-authorization-gateways/config/example-protected-httpbin-configuration.yml
+++ b/examples/sidecar-authorization-gateways/config/example-protected-httpbin-configuration.yml
@@ -1,8 +1,8 @@
 ---
 configuration:
-  node_name: "httpbin"
+  node_name: "protected-httpbin"
   microgateway:
-    - authorize: false
+    - authorize: true
       error_content_type: "text/plain"
       forbidden_response: "forbidden"
       unauthorized_response: "unauthorized"
@@ -11,8 +11,10 @@ configuration:
       pool_count: 1
       pool_size: 10
       max_idle_time: 10
+      required_scopes:
+        GET: ["test"]
       scheme: "http"
-      host: "httpbin.patatoid.fr"
+      host: "httpbin"
       port: 80
       uris: ["/"]
       strip_uri: false

--- a/examples/sidecar-authorization-gateways/docker-compose.yml
+++ b/examples/sidecar-authorization-gateways/docker-compose.yml
@@ -1,0 +1,75 @@
+version: "3"
+
+volumes:
+  boruta-logs:
+
+services:
+  postgres:
+    image: postgres:14
+    environment:
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
+      POSTGRES_DATABASE: "boruta_release"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  boruta-server:
+    image: ghcr.io/malach-it/boruta-server:master
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+      - "8082:8082"
+    volumes:
+      - "boruta-logs:/app/log"
+      - "./config:/app/config"
+    env_file: "../../.env.example"
+    environment:
+      MIX_ENV: "prod"
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
+      POSTGRES_DATABASE: "boruta_release"
+      POSTGRES_HOST: "postgres"
+      BORUTA_GATEWAY_CONFIGURATION_PATH: "config/example-gateway-configuration.yml"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  httpbin-sidecar:
+    image: ghcr.io/malach-it/boruta-gateway:master
+    volumes:
+      - "boruta-logs:/app/log"
+      - "./config:/app/config"
+    env_file: "../../.env.example"
+    environment:
+      MIX_ENV: "prod"
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
+      POSTGRES_DATABASE: "boruta_release"
+      POSTGRES_HOST: "postgres"
+      BORUTA_GATEWAY_CONFIGURATION_PATH: "config/example-httpbin-configuration.yml"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  protected-httpbin-sidecar:
+    image: ghcr.io/malach-it/boruta-gateway:master
+    volumes:
+      - "boruta-logs:/app/log"
+      - "./config:/app/config"
+    env_file: "../../.env.example"
+    environment:
+      MIX_ENV: "prod"
+      POSTGRES_USER: "postgres"
+      POSTGRES_PASSWORD: "postgres"
+      POSTGRES_DATABASE: "boruta_release"
+      POSTGRES_HOST: "postgres"
+      BORUTA_GATEWAY_CONFIGURATION_PATH: "config/example-protected-httpbin-configuration.yml"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  httpbin:
+    image: kennethreitz/httpbin

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Boruta.Umbrella.MixProject do
       ],
       aliases: aliases(),
       releases: [
-        boruta_full: [
+        boruta: [
           include_executables_for: [:unix],
           applications: [
             boruta_web: :permanent,

--- a/mix.exs
+++ b/mix.exs
@@ -12,12 +12,30 @@ defmodule Boruta.Umbrella.MixProject do
       ],
       aliases: aliases(),
       releases: [
-        boruta: [
+        boruta_full: [
           include_executables_for: [:unix],
           applications: [
             boruta_web: :permanent,
             boruta_admin: :permanent,
             boruta_gateway: :permanent
+          ]
+        ],
+        boruta_gateway: [
+          include_executables_for: [:unix],
+          applications: [
+            boruta_gateway: :permanent
+          ]
+        ],
+        boruta_auth: [
+          include_executables_for: [:unix],
+          applications: [
+            boruta_web: :permanent
+          ]
+        ],
+        boruta_admin: [
+          include_executables_for: [:unix],
+          applications: [
+            boruta_admin: :permanent
           ]
         ]
       ]

--- a/static_config/example-protected-httpbin-configuration.yml
+++ b/static_config/example-protected-httpbin-configuration.yml
@@ -3,7 +3,7 @@ configuration:
   node_name: "protected-httpbin"
   microgateway:
     - authorize: true
-      error_content_type: "text"
+      error_content_type: "text/plain"
       forbidden_response: "forbidden"
       unauthorized_response: "unauthorized"
       forwarded_token_secret: "this is a secret"


### PR DESCRIPTION
Split releases and docker images. From now, the project publishes 4 images:
- `boruta-server` containing full applications
- `boruta-auth` containing authentication and authorization
- `boruta-gateway` containing the gateway
- `boruta-admin` containing the administration interface